### PR TITLE
Fixed #43

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,9 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out/src"
+			"outFiles": [
+				"${workspaceRoot}/out/**/*.js"
+			]
 		},
 		{
 			"name": "Launch Tests",
@@ -20,7 +22,9 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out/test"
+			"outFiles": [
+				"${workspaceRoot}/out/**/*.js"
+			]
 		}
 	]
 }

--- a/src/Domain/Lang/DocommentDomainCSharp.ts
+++ b/src/Domain/Lang/DocommentDomainCSharp.ts
@@ -48,6 +48,7 @@ export class DocommentDomainCSharp extends DocommentDomain {
 
         // NG: '////'
         const activeLine: string = this._vsCodeApi.ReadLineAtCurrent();
+        const prevLine: string   = this._vsCodeApi.ReadPreviousLineFromCurrent();
         if (isSlashKey) {
             // NG: '////'
             if (!SyntacticAnalysisCSharp.IsDocCommentStrict(activeLine)) {
@@ -58,7 +59,15 @@ export class DocommentDomainCSharp extends DocommentDomain {
             if (SyntacticAnalysisCSharp.IsDoubleDocComment(activeLine)) {
                 return false;
             }
+
         }
+
+        // check if we should skip any assertions, since this is an already finished template
+        if (SyntacticAnalysisCSharp.IsSummaryTag(activeLine) ||
+            (prevLine != null && SyntacticAnalysisCSharp.IsSummaryTag(prevLine))) {
+            return false;
+        }
+
         if (isEnterKey) {
             // NG: '////'
             if (!SyntacticAnalysisCSharp.IsDocComment(activeLine)) {

--- a/src/SyntacticAnalysis/SyntacticAnalysisCSharp.ts
+++ b/src/SyntacticAnalysis/SyntacticAnalysisCSharp.ts
@@ -29,6 +29,10 @@ export class SyntacticAnalysisCSharp {
         return activeLine.match(/^[ \t]*\/{3} $/) !== null;
     }
 
+    public static IsSummaryTag(activeLine: string): boolean {
+        return this.IsDocComment(activeLine) && activeLine.includes('summary'); // TODO: improve with some regex magic
+    }
+
     /*-------------------------------------------------------------------------
      * Public Method: Code
      *-----------------------------------------------------------------------*/

--- a/test/SyntacticAnalysis/SyntacticAnalysisCSharp.test.ts
+++ b/test/SyntacticAnalysis/SyntacticAnalysisCSharp.test.ts
@@ -217,4 +217,18 @@ suite('SyntacticAnalysis.SyntacticAnalysisCSharp.IsClass Tests', () => {
             assert.equal(SyntacticAnalysisCSharp.IsDocComment(' ///'), true, ' ///');
             assert.equal(SyntacticAnalysisCSharp.IsDocComment(' /// '), true, ' /// ');
         });
+
+    test(`
+        Category: Back-box testing
+        Class   : SyntacticAnalysis.SyntacticAnalysisCSharp
+        Method  : IsSummaryTag
+    `, () => {
+            assert.equal(SyntacticAnalysisCSharp.IsSummaryTag('   /// <summary>'), true, 'open tag');
+            assert.equal(SyntacticAnalysisCSharp.IsSummaryTag(' /// </summary>'), true, 'closing tag');
+            assert.equal(SyntacticAnalysisCSharp.IsSummaryTag('/// hahah its a summary'), true, 'normal comment containing summary');
+
+            assert.equal(SyntacticAnalysisCSharp.IsSummaryTag('santa clause'), false, 'santa');
+            assert.equal(SyntacticAnalysisCSharp.IsSummaryTag('/// da sumary'), false, 'spelling error');
+            assert.equal(SyntacticAnalysisCSharp.IsSummaryTag('///'), false, 'no summary tag');
+        });
 });


### PR DESCRIPTION
as mentioned in #43, the addon has problems with vscode. This comes down to a bug, where we do not check, if we are already inside a valid summary tag.

Note that this fix is very straight forward and could be improved by e.g. using the regex method as done in other methodes in the analyzer as well.