### PR TITLE
Fixed #86 when using @ prefixed identifiers, the prefix should be rem…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
-## 0.1.9 (May 26, 2020)
+## 0.1.10 (May 19, 2020)
+
+* bug fix - When using @ prefixed identifiers, the prefix should be removed in the generated param name. See [#86](https://github.com/kasecato/vscode-docomment/issues/86).
+* upgrade libs
+
+## 0.1.9 (March 26, 2020)
 
 * upgrade libs
 

--- a/src/SyntacticAnalysis/SyntacticAnalysisCSharp.ts
+++ b/src/SyntacticAnalysis/SyntacticAnalysisCSharp.ts
@@ -153,7 +153,7 @@ export class SyntacticAnalysisCSharp {
         }
 
         const generics: RegExpMatchArray = code.match(/<([^<>]*)>/);
-        
+
         const isUnMatched = (generics === null || generics.length !== 2);
         if (isUnMatched) return null;
 
@@ -194,7 +194,7 @@ export class SyntacticAnalysisCSharp {
         const isMatched = (params === null || params.length !== 2);
         if (isMatched) return null;
 
-        let paramName: Array<string> = new Array<string>();
+        let paramNames: Array<string> = new Array<string>();
         params[1].split(',').forEach(param => {
             const hasOptionalParam: boolean = param.match(/\S+\s+\S+\s*=/) !== null;
             const hasTypeInfo: boolean = param.match(/[\w\W]+\s+[\w\W]+/) !== null;
@@ -207,11 +207,15 @@ export class SyntacticAnalysisCSharp {
                 name = param.match(/(\S+)\s*$/);
             }
             if (name !== null && name.length === 2) {
-                paramName.push(name[1]);
+                const hasIdentifer = name[1].startsWith('@');
+                const paramName = (hasIdentifer)
+                    ? name[1].replace('@', '')
+                    : name[1];
+                paramNames.push(paramName);
             }
         });
 
-        return paramName;
+        return paramNames;
     }
 
     public static HasMethodReturn(code: string): boolean {

--- a/test/TestData/X.cs
+++ b/test/TestData/X.cs
@@ -74,4 +74,6 @@ namespace N  // "N:N"
     public delegate List<T> StackEventHandler<T, U>(T sender, U eventArgs);
 
     public class Foo : Bar<string> { }
+
+    void DoSomething(bool @checked) { }
 }


### PR DESCRIPTION
…oved in the generated param name